### PR TITLE
feat: redesign compgen, break changes to completion scripts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
 
 [[package]]
 name = "argc"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fec50030c31a128d293d32a3607e644375bc478c4e47eb92f026e0e0284b6423"
+checksum = "8cfe402590572c3fd2eecfcca5ef8620c33693fe70eb6594ae917a9d5e432bd7"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["command-line-utilities"]
 keywords = ["command-line", "task-runner", "task-automation", "build-tool"]
 
 [dependencies]
-argc = "0.13"
+argc = "0.14"
 anyhow = "1"
 which = "4.2"
 either = "1.8"

--- a/completions/runme.fish
+++ b/completions/runme.fish
@@ -4,18 +4,30 @@
 # To add completion to a argc script, simply add the script name to $ARGC_SCRIPTS.
 
 function __fish_complete_runme
-    set -l line (commandline -opc) (commandline -ct)
-    set -l tokens (echo $line | string trim | string split " " --)
+    set -l tokens (commandline -c | string trim -l | string split " " --)
     set -l runmefile (runme --runme-file 2>/dev/null)
     if test -z $runmefile
         return 0
     end
-    set -l opts (runme --runme-compgen "$runmefile" $tokens[2..-1] 2>/dev/null)
-    if string match -q "__argc_compgen_cmd:*" -- $opts
-        set -l fn_name (string replace "__argc_compgen_cmd:" "" $opts)
-        set opts (runme $fn_name 2>/dev/null)
+    set -l IFS '\n'
+    set -l opts (runme --runme-compgen "$runmefile" "$tokens[2..]" 2>/dev/null)
+    if [ (count $opts) = 0 ]
+        return 0
+    else if [ (count $opts) = 1 ]
+        if string match -qr '^`[^` ]+`' -- "$opts[1]"
+            set -l name (string sub $opts[1] -s 2 -e -1)
+            set opts (runme $name 2>/dev/null)
+        end
     end
-    echo $opts | string trim | string split " " --
+    for item in $opts
+        if test "$item" = "<FILE>" || test "$item" = "<PATH>" || test "$item" = "<FILE>..." || test "$item" = "<PATH>..."
+            __fish_complete_path
+        else if test "$item" = "<DIR>" || test "$item" = "<DIR>..."
+            __fish_complete_directories 
+        else
+            echo $item
+        end
+    end
 end
 
 complete -x -c runme  -n 'true' -a "(__fish_complete_runme)"

--- a/src/main.rs
+++ b/src/main.rs
@@ -136,8 +136,13 @@ USAGE:{usage}"#)
         print!("{}", shell_file.display());
     } else if matches.get_flag("runme-compgen") {
         let (source, cmd_args) = parse_script_args(&script_args)?;
-        let cmd_args: Vec<&str> = cmd_args.iter().map(|v| v.as_str()).collect();
-        print!("{}", argc::compgen(&source, &cmd_args)?.join(" "))
+        let line = if cmd_args.len() == 1 {
+            ""
+        } else {
+            cmd_args[1].as_str()
+        };
+        let candicates = argc::compgen(&source, line)?;
+        candicates.into_iter().for_each(|v| println!("{v}"));
     } else {
         let shell = get_shell_path().ok_or_else(|| anyhow!("Not found shell"))?;
         let (script_dir, script_file) = get_script_path(true).ok_or_else(|| {

--- a/tests/compgen.rs
+++ b/tests/compgen.rs
@@ -12,58 +12,65 @@ bar() { :; }
 
 #[test]
 fn test_compgen() {
-    snapshot_compgen!(SPEC_SCRIPT, &["prog"]);
+    snapshot_compgen!(SPEC_SCRIPT, "");
 }
 
 #[test]
 fn test_compgen_help() {
-    snapshot_compgen!(SPEC_SCRIPT, &["prog", "help"]);
+    snapshot_compgen!(SPEC_SCRIPT, "help");
 }
 
 #[test]
 fn test_compgen_subcommand() {
-    snapshot_compgen!(SPEC_SCRIPT, &["prog", "cmd_option_names"]);
+    snapshot_compgen!(SPEC_SCRIPT, "cmd_option_names ");
 }
 
 #[test]
 fn test_compgen_option_choices() {
-    snapshot_compgen!(SPEC_SCRIPT, &["prog", "cmd_option_names", "--opt7"]);
+    snapshot_compgen!(SPEC_SCRIPT, "cmd_option_names --opt7 ");
+}
+
+#[test]
+fn test_compgen_option_choices2() {
+    snapshot_compgen!(SPEC_SCRIPT, "cmd_option_names --opt7 a");
+}
+
+#[test]
+fn test_compgen_option_choices3() {
+    snapshot_compgen!(SPEC_SCRIPT, "cmd_option_names --opt7 a ");
 }
 
 #[test]
 fn test_compgen_positional() {
-    snapshot_compgen!(SPEC_SCRIPT, &["prog", "cmd_positional_requires"]);
+    snapshot_compgen!(SPEC_SCRIPT, "cmd_positional_requires ");
 }
 
 #[test]
 fn test_compgen_positional_arg() {
-    snapshot_compgen!(SPEC_SCRIPT, &["prog", "cmd_positional_requires", "arg1"]);
+    snapshot_compgen!(SPEC_SCRIPT, "cmd_positional_requires arg1 ");
 }
 
 #[test]
 fn test_compgen_positional_arg2() {
-    snapshot_compgen!(
-        SPEC_SCRIPT,
-        &["prog", "cmd_positional_requires", "arg1", "arg2"]
-    );
-}
-
-#[test]
-fn test_compgen_choice_fn() {
-    snapshot_compgen!(SPEC_SCRIPT, &["prog", "cmd_option_names", "--op10"]);
+    snapshot_compgen!(SPEC_SCRIPT, "cmd_positional_requires arg1 arg2 ");
 }
 
 #[test]
 fn test_compgen_positional_choices() {
-    snapshot_compgen!(SPEC_SCRIPT, &["prog", "cmd_positional_with_choices"]);
+    snapshot_compgen!(SPEC_SCRIPT, "cmd_positional_with_choices ");
 }
 
 #[test]
 fn test_compgen_help_tag() {
-    snapshot_compgen!(HELP_TAG_SCRIPT, &["prog"]);
+    snapshot_compgen!(HELP_TAG_SCRIPT, "");
 }
 
 #[test]
 fn test_compgen_help_tag2() {
-    snapshot_compgen!(HELP_TAG_SCRIPT, &["prog", "help"]);
+    snapshot_compgen!(HELP_TAG_SCRIPT, "help");
+}
+
+#[test]
+fn test_compgen_choice_fn() {
+    snapshot_compgen!(SPEC_SCRIPT, "cmd_option_names --op11 ");
 }

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -70,7 +70,6 @@ macro_rules! snapshot_compgen {
             Err(stderr) => (String::new(), stderr.to_string()),
         };
 
-        let args = $args.join(" ");
         let output = format!(
             r###"RUN
 {}
@@ -81,7 +80,7 @@ STDOUT
 STDERR
 {}
 "###,
-            args, stdout, stderr
+            $args, stdout, stderr
         );
         insta::assert_snapshot!(output);
     };

--- a/tests/snapshots/integration__compgen__compgen.snap
+++ b/tests/snapshots/integration__compgen__compgen.snap
@@ -3,7 +3,7 @@ source: tests/compgen.rs
 expression: output
 ---
 RUN
-prog
+
 
 STDOUT
 cmd_preferred cmd_omitted cmd_option_names cmd_option_formats cmd_option_quotes cmd_flag_formats cmd_positional_only cmd_positional_requires cmd_positional_with_choices cmd_positional_with_default cmd_positional_with_default_fn cmd_positional_with_choices_and_default cmd_positional_with_choices_fn cmd_positional_with_choices_and_required cmd_positional_with_choices_fn_and_required cmd_without_any_arg cmd_alias a alias cmd_with_hyphens

--- a/tests/snapshots/integration__compgen__compgen_help.snap
+++ b/tests/snapshots/integration__compgen__compgen_help.snap
@@ -3,7 +3,7 @@ source: tests/compgen.rs
 expression: output
 ---
 RUN
-prog help
+help
 
 STDOUT
 cmd_preferred cmd_omitted cmd_option_names cmd_option_formats cmd_option_quotes cmd_flag_formats cmd_positional_only cmd_positional_requires cmd_positional_with_choices cmd_positional_with_default cmd_positional_with_default_fn cmd_positional_with_choices_and_default cmd_positional_with_choices_fn cmd_positional_with_choices_and_required cmd_positional_with_choices_fn_and_required cmd_without_any_arg cmd_alias a alias cmd_with_hyphens

--- a/tests/snapshots/integration__compgen__compgen_help_tag.snap
+++ b/tests/snapshots/integration__compgen__compgen_help_tag.snap
@@ -1,10 +1,9 @@
 ---
 source: tests/compgen.rs
-assertion_line: 58
 expression: output
 ---
 RUN
-prog
+
 
 STDOUT
 foo bar help

--- a/tests/snapshots/integration__compgen__compgen_help_tag2.snap
+++ b/tests/snapshots/integration__compgen__compgen_help_tag2.snap
@@ -1,10 +1,9 @@
 ---
 source: tests/compgen.rs
-assertion_line: 63
 expression: output
 ---
 RUN
-prog help
+help
 
 STDOUT
 foo bar

--- a/tests/snapshots/integration__compgen__compgen_option_choices.snap
+++ b/tests/snapshots/integration__compgen__compgen_option_choices.snap
@@ -1,10 +1,9 @@
 ---
 source: tests/compgen.rs
-assertion_line: 30
 expression: output
 ---
 RUN
-prog cmd_option_names --opt7
+cmd_option_names --opt7 
 
 STDOUT
 a b c

--- a/tests/snapshots/integration__compgen__compgen_option_choices2.snap
+++ b/tests/snapshots/integration__compgen__compgen_option_choices2.snap
@@ -3,10 +3,10 @@ source: tests/compgen.rs
 expression: output
 ---
 RUN
-cmd_option_names --op11 
+cmd_option_names --opt7 a
 
 STDOUT
-`_fn_bars`
+a b c
 
 STDERR
 

--- a/tests/snapshots/integration__compgen__compgen_option_choices3.snap
+++ b/tests/snapshots/integration__compgen__compgen_option_choices3.snap
@@ -1,0 +1,13 @@
+---
+source: tests/compgen.rs
+expression: output
+---
+RUN
+cmd_option_names --opt7 a 
+
+STDOUT
+--opt1 --opt2 --opt3 --opt4 --opt5 --opt6 --opt8 --opt9 --op10 --op11
+
+STDERR
+
+

--- a/tests/snapshots/integration__compgen__compgen_positional.snap
+++ b/tests/snapshots/integration__compgen__compgen_positional.snap
@@ -1,10 +1,9 @@
 ---
 source: tests/compgen.rs
-assertion_line: 35
 expression: output
 ---
 RUN
-prog cmd_positional_requires
+cmd_positional_requires 
 
 STDOUT
 <ARG1>

--- a/tests/snapshots/integration__compgen__compgen_positional_arg.snap
+++ b/tests/snapshots/integration__compgen__compgen_positional_arg.snap
@@ -1,10 +1,9 @@
 ---
 source: tests/compgen.rs
-assertion_line: 40
 expression: output
 ---
 RUN
-prog cmd_positional_requires arg1
+cmd_positional_requires arg1 
 
 STDOUT
 <ARG2>...

--- a/tests/snapshots/integration__compgen__compgen_positional_arg2.snap
+++ b/tests/snapshots/integration__compgen__compgen_positional_arg2.snap
@@ -1,10 +1,9 @@
 ---
 source: tests/compgen.rs
-assertion_line: 45
 expression: output
 ---
 RUN
-prog cmd_positional_requires arg1 arg2
+cmd_positional_requires arg1 arg2 
 
 STDOUT
 <ARG2>...

--- a/tests/snapshots/integration__compgen__compgen_positional_choices.snap
+++ b/tests/snapshots/integration__compgen__compgen_positional_choices.snap
@@ -1,10 +1,9 @@
 ---
 source: tests/compgen.rs
-assertion_line: 53
 expression: output
 ---
 RUN
-prog cmd_positional_with_choices
+cmd_positional_with_choices 
 
 STDOUT
 a b

--- a/tests/snapshots/integration__compgen__compgen_subcommand.snap
+++ b/tests/snapshots/integration__compgen__compgen_subcommand.snap
@@ -3,7 +3,7 @@ source: tests/compgen.rs
 expression: output
 ---
 RUN
-prog cmd_option_names
+cmd_option_names 
 
 STDOUT
 --opt1 --opt2 --opt3 --opt4 --opt5 --opt6 --opt7 --opt8 --opt9 --op10 --op11

--- a/tests/spec.sh
+++ b/tests/spec.sh
@@ -65,7 +65,7 @@ cmd_flag_formats() {
 }
 
 # @cmd  Positional one required
-# @arg   arg1!     A required arg
+# @arg   arg1! <ARG>  A required arg
 cmd_positional_only() {
     print_argc_vars
 }
@@ -150,4 +150,4 @@ _fn_bars() {
     echo " a1 a2 a3 "
 }
 
-eval "$(runme --runme-eval "$0" "$@")"
+eval "$(argc "$0" "$@")"


### PR DESCRIPTION
Two difference:

1. `--compgen` accept two arguments only, one for sript path, one for command line buffer.

`runme --runme-compgen ./mycmd1 download` => `runme --runme-compgen ./mycmd1 'download '`

The space in the end is very import. Having space or not having space will generate completely different results. After this PR merged, argc can recognize this difference.

2. Candidates are separated by `\n`, not by ` `